### PR TITLE
Fixes attribute names not being translated for non-default messages (laravel4)

### DIFF
--- a/src/Bllim/Laravalid/Helper.php
+++ b/src/Bllim/Laravalid/Helper.php
@@ -1,7 +1,7 @@
 <?php namespace Bllim\Laravalid;
 /**
  * Helper class
- * 
+ *
  *
  * @package    Laravel Validation For Client-Side
  * @author     Bilal Gultekin <bilal@bilal.im>
@@ -22,4 +22,13 @@ class Helper {
 		return \Crypt::decrypt($data);
 	}
 
+	/**
+	 * Get user friendly attribute name
+	 *
+	 * @return string
+	 */
+	public static function getAttributeName($attribute)
+	{
+		return !\Lang::has('validation.attributes.'.$attribute) ? $attribute : \Lang::get('validation.attributes.'.$attribute);
+	}
 }

--- a/src/Bllim/Laravalid/converter/Base/Converter.php
+++ b/src/Bllim/Laravalid/converter/Base/Converter.php
@@ -1,4 +1,7 @@
 <?php namespace Bllim\Laravalid\Converter\Base;
+
+use Bllim\Laravalid\Helper;
+
 /**
  * Base converter class for converter plugins
  * 
@@ -202,20 +205,10 @@ abstract class Converter {
 	protected function getDefaultErrorMessage($laravelRule, $attribute)
 	{
 		// getting user friendly attribute name
-		$attribute = $this->getAttributeName($attribute);
+		$attribute = Helper::getAttributeName($attribute);
 		$message = \Lang::get('validation.'.$laravelRule, ['attribute' => $attribute]);
 
 		return ['data-msg-'.$laravelRule => $message];
-	}
-
-	/**
-	 * Get user friendly attribute name
-	 *
-	 * @return string
-	 */
-	protected function getAttributeName($attribute)
-	{
-		return !\Lang::has('validation.attributes.'.$attribute) ? $attribute : \Lang::get('validation.attributes.'.$attribute);
 	}
 
 }

--- a/src/Bllim/Laravalid/converter/JqueryValidation/Message.php
+++ b/src/Bllim/Laravalid/converter/JqueryValidation/Message.php
@@ -1,63 +1,64 @@
 <?php namespace Bllim\Laravalid\Converter\JqueryValidation;
 
 use Lang;
+use Bllim\Laravalid\Helper;
 
 class Message extends \Bllim\Laravalid\Converter\Base\Message {
 
-	public function ip($parsedRule, $attribute, $type) 
+	public function ip($parsedRule, $attribute, $type)
 	{
-		$message = Lang::get('validation.'.$parsedRule['name'], ['attribute' => $attribute]);
+		$message = Lang::get('validation.'.$parsedRule['name'], ['attribute' => Helper::getAttributeName($attribute)]);
 		return ['data-msg-ipv4' => $message];
 	}
-	
-	public function alpha($parsedRule, $attribute, $type) 
+
+	public function alpha($parsedRule, $attribute, $type)
 	{
-		$message = Lang::get('validation.'.$parsedRule['name'], ['attribute' => $attribute]);
+		$message = Lang::get('validation.'.$parsedRule['name'], ['attribute' => Helper::getAttributeName($attribute)]);
 		return ['data-msg-regex' => $message];
 	}
-	
-	public function alphanum($parsedRule, $attribute, $type) 
+
+	public function alphanum($parsedRule, $attribute, $type)
 	{
-		$message = Lang::get('validation.'.$parsedRule['name'], ['attribute' => $attribute]);
+		$message = Lang::get('validation.'.$parsedRule['name'], ['attribute' => Helper::getAttributeName($attribute)]);
 		return ['data-msg-regex' => $message];
 	}
-	
+
 	public function max($parsedRule, $attribute, $type)
 	{
-		$message = Lang::get('validation.'.$parsedRule['name'].'.'.$type, ['attribute' => $attribute, 'max' => $parsedRule['parameters'][0]]);
+		$message = Lang::get('validation.'.$parsedRule['name'].'.'.$type, ['attribute' => Helper::getAttributeName($attribute), 'max' => $parsedRule['parameters'][0]]);
 		switch ($type) {
 			case 'numeric':
 				return ['data-msg-max' => $message];
 				break;
-			
+
 			default:
 				return ['data-msg-maxlength' => $message];
 				break;
 		}
 	}
-	
+
 	public function min($parsedRule, $attribute, $type)
 	{
-		$message = Lang::get('validation.'.$parsedRule['name'].'.'.$type, ['attribute' => $attribute, 'min' => $parsedRule['parameters'][0]]);
+		$message = Lang::get('validation.'.$parsedRule['name'].'.'.$type, ['attribute' => Helper::getAttributeName($attribute), 'min' => $parsedRule['parameters'][0]]);
 		switch ($type) {
 			case 'numeric':
 				return ['data-msg-min' => $message];
 				break;
-			
+
 			default:
 				return ['data-msg-minlength' => $message];
 				break;
 		}
 	}
-	
+
 	public function between($parsedRule, $attribute, $type)
 	{
-		$message = Lang::get('validation.'.$parsedRule['name'].'.'.$type, ['attribute' => $attribute, 'min' => $parsedRule['parameters'][0], 'max' => $parsedRule['parameters'][1]]);
+		$message = Lang::get('validation.'.$parsedRule['name'].'.'.$type, ['attribute' => Helper::getAttributeName($attribute), 'min' => $parsedRule['parameters'][0], 'max' => $parsedRule['parameters'][1]]);
 		switch ($type) {
 			case 'numeric':
 				return ['data-msg-range' => $message];
 				break;
-			
+
 			default:
 				return ['data-msg-minlength' => $message, 'data-msg-maxlength' => $message];
 				break;


### PR DESCRIPTION
(laravel4) At the moment, raw attribute names are used for all rules handled in the JqueryValidation `Message` class. This PR moves the `getAttributeName` method from Converter to Helper and adapts the `Message` class to call this method.
