### PR TITLE
moved validation message generation into a Helper method

### DIFF
--- a/src/Bllim/Laravalid/FormBuilder.php
+++ b/src/Bllim/Laravalid/FormBuilder.php
@@ -95,7 +95,7 @@ class FormBuilder extends \Illuminate\Html\FormBuilder {
 	 */
 	public function input($type, $name, $value = null, $options = [])
 	{
-		$options = $this->converter->convert($name) + $options;
+		$options = $this->converter->convert(Helper::getFormAttribute($name)) + $options;
 		return parent::input($type, $name, $value, $options);
 	}
 
@@ -104,7 +104,7 @@ class FormBuilder extends \Illuminate\Html\FormBuilder {
 	 */
 	public function textarea($name, $value = null, $options = [])
 	{
-		$options = $this->converter->convert($name) + $options;
+		$options = $this->converter->convert(Helper::getFormAttribute($name)) + $options;
 		return parent::textarea($name, $value, $options);
 	}
 
@@ -113,13 +113,13 @@ class FormBuilder extends \Illuminate\Html\FormBuilder {
 	 */
 	public function select($name, $list = [], $selected = null, $options = [])
 	{
-		$options = $this->converter->convert($name) + $options;
+		$options = $this->converter->convert(Helper::getFormAttribute($name)) + $options;
 		return parent::select($name, $list, $selected, $options);
 	}
 
 	protected function checkable($type, $name, $value, $checked, $options)
 	{
-		$options = $this->converter->convert($name) + $options;
+		$options = $this->converter->convert(Helper::getFormAttribute($name)) + $options;
 		return parent::checkable($type, $name, $value, $checked, $options);
 	}
 

--- a/src/Bllim/Laravalid/Helper.php
+++ b/src/Bllim/Laravalid/Helper.php
@@ -22,4 +22,26 @@ class Helper {
 		return \Crypt::decrypt($data);
 	}
 
+	/**
+	 * Get user friendly validation message
+	 *
+	 * @return string
+	 */
+	public static function getValidationMessage($attribute, $rule, $data = [], $type = null)
+	{
+		$path = $rule;
+		if ($type !== null)
+		{
+			$path .= '.' . $type;
+		}
+
+		if (\Lang::has('validation.custom.' . $attribute . '.' . $path))
+		{
+			$path = 'custom.' . $attribute . '.' . $path;
+		}
+
+		$niceName = !\Lang::has('validation.attributes.'.$attribute) ? $attribute : \Lang::get('validation.attributes.'.$attribute);
+
+		return \Lang::get('validation.' . $path, $data + ['attribute' => $niceName]);
+	}
 }

--- a/src/Bllim/Laravalid/Helper.php
+++ b/src/Bllim/Laravalid/Helper.php
@@ -44,4 +44,14 @@ class Helper {
 
 		return \Lang::get('validation.' . $path, $data + ['attribute' => $niceName]);
 	}
+
+	/**
+	 * Get the raw attribute name without array braces
+	 *
+	 * @return string
+	 */
+	public static function getFormAttribute($name)
+	{
+		return substr($name, -2) === '[]' ? substr($name, 0, -2) : $name;
+	}
 }

--- a/src/Bllim/Laravalid/converter/Base/Converter.php
+++ b/src/Bllim/Laravalid/converter/Base/Converter.php
@@ -1,4 +1,7 @@
 <?php namespace Bllim\Laravalid\Converter\Base;
+
+use Bllim\Laravalid\Helper;
+
 /**
  * Base converter class for converter plugins
  * 
@@ -173,6 +176,10 @@ abstract class Converter {
 			{
 				return 'numeric';
 			}
+			elseif ($parsedRule['name'] === 'array')
+			{
+				return 'array';
+			}
 		}
 
 		return 'string';
@@ -201,21 +208,10 @@ abstract class Converter {
 	 */
 	protected function getDefaultErrorMessage($laravelRule, $attribute)
 	{
-		// getting user friendly attribute name
-		$attribute = $this->getAttributeName($attribute);
-		$message = \Lang::get('validation.'.$laravelRule, ['attribute' => $attribute]);
+		// getting user friendly validation message
+		$message = Helper::getValidationMessage($attribute, $laravelRule);
 
 		return ['data-msg-'.$laravelRule => $message];
-	}
-
-	/**
-	 * Get user friendly attribute name
-	 *
-	 * @return string
-	 */
-	protected function getAttributeName($attribute)
-	{
-		return !\Lang::has('validation.attributes.'.$attribute) ? $attribute : \Lang::get('validation.attributes.'.$attribute);
 	}
 
 }

--- a/src/Bllim/Laravalid/converter/JqueryValidation/Message.php
+++ b/src/Bllim/Laravalid/converter/JqueryValidation/Message.php
@@ -1,30 +1,31 @@
 <?php namespace Bllim\Laravalid\Converter\JqueryValidation;
 
 use Lang;
+use Bllim\Laravalid\Helper;
 
 class Message extends \Bllim\Laravalid\Converter\Base\Message {
 
 	public function ip($parsedRule, $attribute, $type) 
 	{
-		$message = Lang::get('validation.'.$parsedRule['name'], ['attribute' => $attribute]);
+		$message = Helper::getValidationMessage($attribute, $parsedRule['name']);
 		return ['data-msg-ipv4' => $message];
 	}
 	
 	public function alpha($parsedRule, $attribute, $type) 
 	{
-		$message = Lang::get('validation.'.$parsedRule['name'], ['attribute' => $attribute]);
+		$message = Helper::getValidationMessage($attribute, $parsedRule['name']);
 		return ['data-msg-regex' => $message];
 	}
 	
 	public function alphanum($parsedRule, $attribute, $type) 
 	{
-		$message = Lang::get('validation.'.$parsedRule['name'], ['attribute' => $attribute]);
+		$message = Helper::getValidationMessage($attribute, $parsedRule['name']);
 		return ['data-msg-regex' => $message];
 	}
 	
 	public function max($parsedRule, $attribute, $type)
 	{
-		$message = Lang::get('validation.'.$parsedRule['name'].'.'.$type, ['attribute' => $attribute, 'max' => $parsedRule['parameters'][0]]);
+		$message = Helper::getValidationMessage($attribute, $parsedRule['name'], ['max' => $parsedRule['parameters'][0]], $type);
 		switch ($type) {
 			case 'numeric':
 				return ['data-msg-max' => $message];
@@ -38,7 +39,7 @@ class Message extends \Bllim\Laravalid\Converter\Base\Message {
 	
 	public function min($parsedRule, $attribute, $type)
 	{
-		$message = Lang::get('validation.'.$parsedRule['name'].'.'.$type, ['attribute' => $attribute, 'min' => $parsedRule['parameters'][0]]);
+		$message = Helper::getValidationMessage($attribute, $parsedRule['name'], ['min' => $parsedRule['parameters'][0]], $type);
 		switch ($type) {
 			case 'numeric':
 				return ['data-msg-min' => $message];
@@ -52,7 +53,7 @@ class Message extends \Bllim\Laravalid\Converter\Base\Message {
 	
 	public function between($parsedRule, $attribute, $type)
 	{
-		$message = Lang::get('validation.'.$parsedRule['name'].'.'.$type, ['attribute' => $attribute, 'min' => $parsedRule['parameters'][0], 'max' => $parsedRule['parameters'][1]]);
+		$message = Helper::getValidationMessage($attribute, $parsedRule['name'], ['min' => $parsedRule['parameters'][0], 'max' => $parsedRule['parameters'][1]], $type);
 		switch ($type) {
 			case 'numeric':
 				return ['data-msg-range' => $message];

--- a/src/Bllim/Laravalid/converter/JqueryValidation/Message.php
+++ b/src/Bllim/Laravalid/converter/JqueryValidation/Message.php
@@ -22,7 +22,19 @@ class Message extends \Bllim\Laravalid\Converter\Base\Message {
 		$message = Helper::getValidationMessage($attribute, $parsedRule['name']);
 		return ['data-msg-regex' => $message];
 	}
-	
+
+	public function integer($parsedRule, $attribute, $type)
+	{
+		$message = Helper::getValidationMessage($attribute, $parsedRule['name']);
+		return ['data-msg-number' => $message];
+	}
+
+	public function numeric($parsedRule, $attribute, $type)
+	{
+		$message = Helper::getValidationMessage($attribute, $parsedRule['name']);
+		return ['data-msg-number' => $message];
+	}
+
 	public function max($parsedRule, $attribute, $type)
 	{
 		$message = Helper::getValidationMessage($attribute, $parsedRule['name'], ['max' => $parsedRule['parameters'][0]], $type);


### PR DESCRIPTION
This PR obsoletes my other pull request, making validation message generation more standardized by moving its logic to a `Helper` method. Attribute translations and custom validation messages (`validation.custom.[attribute].[rule]`) are honored.
