### PR TITLE
make unique/exists rules use jquery-validation's remote rule rather than a synchronous request

### DIFF
--- a/public/jquery.validate.laravalid.js
+++ b/public/jquery.validate.laravalid.js
@@ -2,32 +2,3 @@ $.validator.addMethod("regex", function(value, element, regexp) {
     var regex = new RegExp(regexp);
     return this.optional(element) || regex.test(value);
 }, 'Format is invalid');
-
-$.validator.addMethod("unique", function(value, element, data) {
-	return laravalidremote(value, element, data);
-}, 'Format is invalid');
-
-$.validator.addMethod("exists", function(value, element, data) {
-	return laravalidremote(value, element, data);
-}, 'Format is invalid');
-
-function laravalidremote(value, element, data)
-{
-	var route = $(element).attr('data-route');
-	var token = $(element).parents('form').find('[name="_token"]').first().val();
-	var validStatus;
-	$.ajax({
-	  type: 'POST',
-	  url: route,
-	  data: {validationParameters: data, value: value, _token: token},
-	  success: function(data){
-	  	validStatus = data.valid;
-	  },
-	  fail: function(data){
-	  	validStatus = false;
-	  },
-	  async:false
-	});
-	
-	return validStatus;
-}

--- a/src/Bllim/Laravalid/converter/Base/Route.php
+++ b/src/Bllim/Laravalid/converter/Base/Route.php
@@ -32,11 +32,23 @@ abstract class Route extends Container {
 
 	public function defaultRoute($name, $parameters)
 	{
+		$params = Helper::decrypt($parameters['params']);
+		unset($parameters['params']);
+
+		$rules = array();
+		foreach ($parameters as $k => $v)
+		{
+			$rules[$k] = $name . ':' . $params;
+		}
+
 		$validator = \Validator::make(
-		    array('input' => $parameters['value']),
-		    array('input' => $name.':'.Helper::decrypt($parameters['validationParameters']))
+		    $parameters,
+		    $rules
 		);
 
-		return ['valid' => !$validator->fails(), 'messages' => $validator->messages()];
+		if (!$validator->fails())
+			return \Response::json(true);
+
+		return \Response::json($validator->messages()->first());
 	}
 }

--- a/src/Bllim/Laravalid/converter/JqueryValidation/Rule.php
+++ b/src/Bllim/Laravalid/converter/JqueryValidation/Rule.php
@@ -124,20 +124,20 @@ class Rule extends \Bllim\Laravalid\Converter\Base\Rule {
 		}
 	}
 
-	public function unique($parsedRule, $attribute, $type) 
+	public function unique($parsedRule, $attribute, $type)
 	{
 		$param = implode(',', $parsedRule['parameters']);
 		$encrpytedParam = Helper::encrypt($param);
 		$route = \Config::get('laravalid.route', 'laravalid');
-		return ['data-rule-unique' => $encrpytedParam, 'data-route' => $route.'/unique'];
+		return ['data-rule-remote' => '/' . $route . '/unique?params=' . $encrpytedParam];
 	}
 
-	public function exists($parsedRule, $attribute, $type) 
+	public function exists($parsedRule, $attribute, $type)
 	{
 		$param = implode(',', $parsedRule['parameters']);
 		$encrpytedParam = Helper::encrypt($param);
 		$route = \Config::get('laravalid.route', 'laravalid');
-		return ['data-rule-unique' => $encrpytedParam, 'data-route' => $route.'/exists'];
+		return ['data-rule-remote' => '/' . $route . '/exists?params=' . $encrpytedParam];
 	}
 
 


### PR DESCRIPTION
This PR changes the rule conversion for 'unique' and 'exists' to use of the 'remote' rule provided by the jQuery validation plugin.
