### PR TITLE
Fix travis unit test issues for Laravel 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --no-progress
 
-script: phpunit
+script: vendor/bin/phpunit

--- a/tests/Bllim/Laravalid/Converter/ConverterTest.php
+++ b/tests/Bllim/Laravalid/Converter/ConverterTest.php
@@ -42,14 +42,13 @@ class ConverterTest extends \PHPUnit_Framework_TestCase
         $translator = $test->getMock('Illuminate\Translation\Translator', !$trans ? ['has'] : ['has', 'get'], [$loader, 'en']);
         $translator->expects($test->any())->method('has')->willReturn(false);
 
+        $view = $test->getMock('Illuminate\Contracts\View\Factory');
+        $mocks = compact('config', 'url', 'encrypter', 'translator', 'view');
+
         $app = $test->getMock('Illuminate\Container\Container', ['make']);
-        $app->expects($test->any())->method('make')->willReturnMap([
-            ['config', [], $config],
-            ['url', [], $url],
-            ['encrypter', [], $encrypter],
-            ['translator', [], $translator],
-            ['view', [], $test->getMock('Illuminate\Contracts\View\Factory')],
-        ]);
+        $app->expects($test->any())->method('make')->willReturnCallback(function ($abstract) use ($mocks) {
+            return isset($mocks[$abstract]) ? $mocks[$abstract] : null;
+        });
 
         return $app;
     }

--- a/tests/Bllim/Laravalid/ServiceProviderTest.php
+++ b/tests/Bllim/Laravalid/ServiceProviderTest.php
@@ -38,13 +38,16 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
         $config = $this->getMock('ArrayAccess', ['get', 'set', 'offsetExists', 'offsetGet', 'offsetSet', 'offsetUnset']);//Illuminate\Config\Repository
         $session = $this->getMock('Illuminate\Session\Store', ['token'], [], '', false);
 
-        $app->expects($this->atLeast(5))->method('make')->withConsecutive(['config'], ['config'], ['url'])->willReturnMap([
-            ['config', [], $config],
-            ['url', [], $url],
-            ['session.store', [], $session],
-            ['html', [], &$html],
-            ['view', [], $this->getMock('Illuminate\Contracts\View\Factory')],
-        ]);
+        $mocks = [
+            'config' => $config,
+            'url' => $url,
+            'session.store' => $session,
+            'html' => &$html,
+            'view' => $this->getMock('Illuminate\Contracts\View\Factory'),
+        ];
+        $app->expects($this->atLeast(5))->method('make')->withConsecutive(['config'], ['config'], ['url'])->willReturnCallback(function ($abstract) use ($mocks) {
+            return isset($mocks[$abstract]) ? $mocks[$abstract] : null;
+        });
 
         $config->expects($this->once())->method('get')->with('laravalid', [])->willReturnArgument(1);
         $config->expects($this->once())->method('set')
@@ -70,17 +73,15 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
         $router = $this->getMock('Illuminate\Routing\Router', ['any'], [], '', false);
         $route = $this->getMock('Illuminate\Routing\Route', ['where'], [], '', false);
 
-        $form = $this->getMock(__NAMESPACE__ . '\FormBuilder', ['converter'], [], '', false);
+        $laravalid = $this->getMock(__NAMESPACE__ . '\FormBuilder', ['converter'], [], '', false);
         $converter = $this->getMock(__NAMESPACE__ . '\Converter\Base\Converter', ['route'], [], '', false);
-        $valid = $this->getMock(__NAMESPACE__ . '\Converter\Base\Route', ['convert'], [], '', false);
+        $vRoute = $this->getMock(__NAMESPACE__ . '\Converter\Base\Route', ['convert'], [], '', false);
         $request = $this->getMock('Illuminate\Http\Request', ['all'], [], '', false);
 
-        $app->expects($this->atLeast(4))->method('make')->withConsecutive(['path.config'], ['path.public'])->willReturnMap([
-            ['config', [], $config],
-            ['router', [], $router],
-            ['laravalid', [], $form],
-            ['request', [], $request],
-        ]);
+        $mocks = compact('config', 'router', 'laravalid', 'request');
+        $app->expects($this->atLeast(4))->method('make')->withConsecutive(['path.config'], ['path.public'])->willReturnCallback(function ($abstract) use ($mocks) {
+            return isset($mocks[$abstract]) ? $mocks[$abstract] : null;
+        });
 
         $config->expects($this->once())->method('offsetGet')->with('laravalid.route')->willReturn('laravalid');
 
@@ -91,9 +92,9 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
         });
         $route->expects($this->once())->method('where')->with('rule', '[\w-]+');
 
-        $form->expects($this->once())->method('converter')->willReturn($converter);
-        $converter->expects($this->once())->method('route')->willReturn($valid);
-        $valid->expects($this->once())->method('convert')->willReturnCallback(function () {
+        $laravalid->expects($this->once())->method('converter')->willReturn($converter);
+        $converter->expects($this->once())->method('route')->willReturn($vRoute);
+        $vRoute->expects($this->once())->method('convert')->willReturnCallback(function () {
             return json_encode(func_get_args());
         });
         $request->expects($this->once())->method('all')->willReturn(['params' => '~']);


### PR DESCRIPTION
* Fix travis unit test issues for PHP 5.6
* Update travis config file to pass unit test for `hhvm`